### PR TITLE
Poisson: small optimizations on the numba implementation

### DIFF
--- a/poisson/src/numba/poisson_disk.py
+++ b/poisson/src/numba/poisson_disk.py
@@ -19,8 +19,8 @@ def run_poisson(desired_samples = 100000):
     
     @numba.jit(nopython=True)
     def coords_to_index(coords):
-        x, y = (coords * inv_dx)
-        return int(x), int(y)
+        cx, cy = coords
+        return int(cx * inv_dx), int(cy * inv_dx)
     
     
     @numba.jit(nopython=True)
@@ -32,13 +32,15 @@ def run_poisson(desired_samples = 100000):
     @numba.jit(nopython=True)
     def generate_random_direction():
         theta = random() * 2 * pi
-        return np.array([cos(theta), sin(theta)])
+        return cos(theta), sin(theta)
     
     
     @numba.jit(nopython=True)
     def generate_around_point(p):
+        px, py = p
+        gx, gy = generate_random_direction()
         rad = (random() + 1) * radius
-        return p + rad * generate_random_direction()
+        return px + rad * gx, py + rad * gy
     
     
     @numba.jit(nopython=True)


### PR DESCRIPTION
The original `numba` implementation returns temporary `np.array`s, which involves memory allocations and greatly slows down the overall performance. The issue is fixed in this PR.

The following raw data are measured on my 10-core M1 Max CPU:
```python
# original numba implementation
numba_sample_results = {'numba_cpu': [{'desired_samples': 1000, 'time_ms': 12.972124997759238}, {'desired_samples': 5000, 'time_ms': 82.63947499799542}, {'desired_samples': 10000, 'time_ms': 175.24015000090003}, {'desired_samples': 50000, 'time_ms': 980.5988415959291}, {'desired_samples': 100000, 'time_ms': 1046.57176680048}]}

# numba after my small optimizatons
numba_sample_results = {'numba_cpu': [{'desired_samples': 1000, 'time_ms': 8.382624998921528}, {'desired_samples': 5000, 'time_ms': 52.02877499978058}, {'desired_samples': 10000, 'time_ms': 111.26214999821968}, {'desired_samples': 50000, 'time_ms': 622.672950004926}, {'desired_samples': 100000, 'time_ms': 654.1040082054678}]}

# numpy and taichi
numpy_sample_results = {'numpy_cpu': [{'desired_samples': 1000, 'time_ms': 848.6075916036498}, {'desired_samples': 5000, 'time_ms': 5255.37004180369}, {'desired_samples': 10000, 'time_ms': 10958.730625000317}, {'desired_samples': 50000, 'time_ms': 60349.70868320088}, {'desired_samples': 100000, 'time_ms': 64300.79467500327}]}
taichi_sample_results = {'taichi_cpu': [{'desired_samples': 1000, 'time_ms': 19.43964166760755}, {'desired_samples': 5000, 'time_ms': 94.94831666622}, {'desired_samples': 10000, 'time_ms': 190.26958893518895}, {'desired_samples': 50000, 'time_ms': 952.8907805351386}, {'desired_samples': 100000, 'time_ms': 1025.9536333323922}]}

```

And the plots before and after the optimizations:
![bench-original](https://user-images.githubusercontent.com/7614925/176423909-1652512b-7c80-487c-a652-65f18aeb312f.png)
![bench-opt](https://user-images.githubusercontent.com/7614925/176423961-db6b0415-cfae-4dfc-b476-53c31bbd645e.png)
